### PR TITLE
Update video in playlist

### DIFF
--- a/src/main/java/com/google/sps/servlets/VerifyRoomServlet.java
+++ b/src/main/java/com/google/sps/servlets/VerifyRoomServlet.java
@@ -46,7 +46,7 @@ public final class VerifyRoomServlet extends HttpServlet {
     long currentRoomId = Long.parseLong(tempStringOfRoomId);
     Room currentRoom = Room.fromRoomId(currentRoomId);
     
-    response.getWriter().println(currentRoom != null && isUserOnMemberList(user, currentRoom));
+    response.getWriter().println(currentRoom != null /*&& isUserOnMemberList(user, currentRoom)*/);
 
   }
 

--- a/src/main/java/com/google/sps/servlets/VerifyRoomServlet.java
+++ b/src/main/java/com/google/sps/servlets/VerifyRoomServlet.java
@@ -46,7 +46,7 @@ public final class VerifyRoomServlet extends HttpServlet {
     long currentRoomId = Long.parseLong(tempStringOfRoomId);
     Room currentRoom = Room.fromRoomId(currentRoomId);
     
-    response.getWriter().println(currentRoom != null /*&& isUserOnMemberList(user, currentRoom)*/);
+    response.getWriter().println(currentRoom != null && isUserOnMemberList(user, currentRoom));
 
   }
 

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -1,11 +1,11 @@
 const STATE_LISTENER_TIMER_MS = 1000;
 const PLAYER_SECONDS_DISCREPANCY = 2;
-const PLAYER_STATE_UNSTARTED = "-1"
-const PLAYER_STATE_ENDED = "0";
-const PLAYER_STATE_PLAYED = "1";
-const PLAYER_STATE_PAUSED = "2";
-const PLAYER_STATE_BUFFERING = "3";
-const PLAYER_STATE_VIDEO_CUED = "5";
+const PLAYER_STATE_UNSTARTED = "UNSTARTED"
+const PLAYER_STATE_ENDED = "ENDED";
+const PLAYER_STATE_PLAYED = "PLAYING";
+const PLAYER_STATE_PAUSED = "PAUSED";
+const PLAYER_STATE_BUFFERING = "BUFFERING";
+const PLAYER_STATE_VIDEO_CUED = "CUED";
 const YT_BASE_URL = "https://www.youtube.com/embed/";
 const SYNC_PATH_WITH_QUERY_PARAM = '/sync-room?roomId=';
 var roomId;
@@ -51,8 +51,9 @@ async function fetchPrivateRoomVideo(currentRoomId) {
     let roomPromise = await fetch('/collect-video?roomId='+roomId);
     // fetch the json-version of the urls for all the youtube videos
     let privateRoom = await roomPromise.json();
+    console.log(privateRoom);
     // play video of where private room is at
-    currentVideoId = privateRoom.Url.substring(YT_BASE_URL.length())
+    currentVideoId = privateRoom.id;
 }
 
 // load the playlist of videos to the container
@@ -126,8 +127,13 @@ async function listenForStateChange(){
     // When the video is done, the servlet sends back the next videos id
     // This will not match the currentVideoId, so you must update the current
     // video to match that of the private rooms video
-    if(privateRoomData.Id !== currentVideoId){
-        loadRoomVideo(privateRoomData.Id, privateRoomData.timestamp);
+    console.log(privateRoomData);
+    console.log("OUTSIDE THE IF STATEMENT");
+    if(privateRoomData.id !== currentVideoId){
+        console.log(privateRoomData);
+        console.log(currentVideoId);
+        console.log("About to play the next video");
+        loadRoomVideo(privateRoomData.id, privateRoomData.timestamp);
     }
     // Change state to match group state
     if(privateRoomData.currentState === PLAYER_STATE_UNSTARTED) {
@@ -147,6 +153,11 @@ async function listenForStateChange(){
     } else {
         console.log('Unknown State');
     }
+}
+
+function getCurrentVideo(){
+    var currentVideoIndex = youtubePlayer.getPlaylistIndex();
+    return playlistIds[currentVideoIndex];
 }
 
 // Send the user's state to the servlet every time their state changes

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -113,8 +113,8 @@ async function listenForStateChange(){
     // fetch the json-version of the urls for all the youtube videos
     let privateRoomData = await privateRoomDataPromise.json();
     // Change timestamp to match group timestamp if client is not within two seconds of room
-    if(Math.abs(playerTimeStamp - privateRoomData.timestamp) >= PLAYER_SECONDS_DISCREPANCY){
-        youtubePlayer.seekTo(privateRoomData.timestamp);
+    if(Math.abs(playerTimeStamp - privateRoomData.currentVideoTimestamp) >= PLAYER_SECONDS_DISCREPANCY){
+        youtubePlayer.seekTo(privateRoomData.currentVideoTimestamp);
     }
     // When the video is done, the servlet sends back the next videos id
     // This will not match the currentVideoId, so you must update the current

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -53,16 +53,11 @@ async function fetchPrivateRoomVideo(currentRoomId) {
     currentVideoId = privateRoom.id;
 }
 
-// Load the current video of the private room from the specified start time
-function loadRoomVideo(currentVideoId, startSeconds){
-    youtubePlayer.loadVideoById(currentVideoId, startSeconds);
-}
-
 // The API will call this function when the video player is ready.
 function onPlayerReady(event) {
     document.getElementById('player-div').style.borderColor = '#FF6D00';
     console.log('In the on player ready function');
-    loadRoomVideo(currentVideoId, 0);
+    youtubePlayer.loadVideoById(currentVideoId, 0);
 }
 
 // This code loads the IFrame Player API code asynchronously.
@@ -126,7 +121,7 @@ async function listenForStateChange(){
     // video to match that of the private rooms video
     if(privateRoomData.id !== currentVideoId){
         currentVideoId = privateRoomData.id;
-        loadRoomVideo(privateRoomData.id, privateRoomData.timestamp);
+        youtubePlayer.loadVideoById(privateRoomData.id, privateRoomData.timestamp);
     }
     // Change state to match group state
     if(privateRoomData.currentState === PLAYER_STATE_UNSTARTED) {

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -51,7 +51,6 @@ async function fetchPrivateRoomVideo(currentRoomId) {
     let roomPromise = await fetch('/collect-video?roomId='+roomId);
     // fetch the json-version of the urls for all the youtube videos
     let privateRoom = await roomPromise.json();
-    console.log(privateRoom);
     // play video of where private room is at
     currentVideoId = privateRoom.id;
 }
@@ -127,12 +126,8 @@ async function listenForStateChange(){
     // When the video is done, the servlet sends back the next videos id
     // This will not match the currentVideoId, so you must update the current
     // video to match that of the private rooms video
-    console.log(privateRoomData);
-    console.log("OUTSIDE THE IF STATEMENT");
     if(privateRoomData.id !== currentVideoId){
-        console.log(privateRoomData);
-        console.log(currentVideoId);
-        console.log("About to play the next video");
+        currentVideoId = privateRoomData.id;
         loadRoomVideo(privateRoomData.id, privateRoomData.timestamp);
     }
     // Change state to match group state

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -111,6 +111,10 @@ window.setInterval(function(){
 // the time, video id, and state of their personal player accordingly
 async function listenForStateChange(){
     let privateRoomDataPromise = await fetch(SYNC_PATH_WITH_QUERY_PARAM+roomId);
+    if(privateRoomDataPromise.status === 410){
+        fetch(`/delete-room?roomId=${roomId.toString()}`,{method:'DELETE'})
+        redirectPage(false);
+    }
     // fetch the json-version of the urls for all the youtube videos
     let privateRoomData = await privateRoomDataPromise.json();
     // Change timestamp to match group timestamp if client is not within two seconds of room
@@ -142,6 +146,11 @@ async function listenForStateChange(){
     } else {
         console.log('Unknown State');
     }
+}
+
+function getCurrentVideo(){
+    var currentVideoIndex = youtubePlayer.getPlaylistIndex();
+    return playlistIds[currentVideoIndex];
 }
 
 // Send the user's state to the servlet every time their state changes

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -53,7 +53,6 @@ async function fetchPrivateRoomVideo(currentRoomId) {
     let privateRoom = await roomPromise.json();
     // play video of where private room is at
     currentVideoId = privateRoom.Id;
-    loadRoomVideo(currentVideoId, privateRoom.timestamp);
 }
 
 // load the playlist of videos to the container
@@ -63,6 +62,13 @@ function loadRoomPlaylist(){
 
 function loadRoomVideo(currentVideoId, startSeconds){
     youtubePlayer.loadVideoById(currentVideoId, startSeconds);
+}
+
+// The API will call this function when the video player is ready.
+function onPlayerReady(event) {
+    document.getElementById('player-div').style.borderColor = '#FF6D00';
+    console.log('In the on player ready function');
+    loadRoomVideo(currentVideoId, 0);
 }
 
 // This code loads the IFrame Player API code asynchronously.
@@ -146,13 +152,6 @@ async function listenForStateChange(){
 // Send the user's state to the servlet every time their state changes
 function updateCurrentState(currentState, currentTime){
     fetch(`/sync-room?roomId=${roomId.toString()}&userState=${currentState}&timeStamp=${currentTime}`,{method:'POST'})
-}
-
-// The API will call this function when the video player is ready.
-function onPlayerReady(event) {
-    document.getElementById('player-div').style.borderColor = '#FF6D00';
-    console.log('In the on player ready function');
-    loadRoomVideo(playlistIds[0], 0);
 }
 
 /* Chat Room Feature */

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -52,7 +52,7 @@ async function fetchPrivateRoomVideo(currentRoomId) {
     // fetch the json-version of the urls for all the youtube videos
     let privateRoom = await roomPromise.json();
     // play video of where private room is at
-    currentVideoId = privateRoom.Id;
+    currentVideoId = privateRoom.Url.substring(YT_BASE_URL.length())
 }
 
 // load the playlist of videos to the container

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -13,6 +13,7 @@ var playlistUrls;
 var playlistIds;
 var youtubePlayer;
 var playerTimeStamp;
+var currentVideoId;
 
 // Calls the three functions associated with loading the room's iframe
 async function loadPlayerDiv(){
@@ -47,21 +48,21 @@ function getRoomId(url) {
  */
 async function fetchPrivateRoomVideo(currentRoomId) {
     // Check that the current room id exits, then return playlist of given room
-    let roomPromise = await fetch('/collect-videos?roomId='+roomId);
+    let roomPromise = await fetch('/collect-video?roomId='+roomId);
     // fetch the json-version of the urls for all the youtube videos
-    let roomVideoUrls = await roomPromise.json();
-    // create an array of all the YT videos' urls
-    playlistIds = extractVideoIds(roomVideoUrls);
-}
-
-// Take the array of urls and create an array of their youtube ids
-function extractVideoIds(roomVideoUrls){
-    return roomVideoUrls.map(id => id.substring(YT_BASE_URL.length));
+    let privateRoom = await roomPromise.json();
+    // play video of where private room is at
+    currentVideoId = privateRoom.Id;
+    loadRoomVideo(currentVideoId, privateRoom.timestamp);
 }
 
 // load the playlist of videos to the container
 function loadRoomPlaylist(){
     youtubePlayer.loadPlaylist({playlist: playlistIds});
+}
+
+function loadRoomVideo(currentVideoId, startSeconds){
+    youtubePlayer.loadVideoById(currentVideoId, startSeconds);
 }
 
 // This code loads the IFrame Player API code asynchronously.
@@ -116,6 +117,12 @@ async function listenForStateChange(){
     if(Math.abs(playerTimeStamp - privateRoomData.timestamp) >= PLAYER_SECONDS_DISCREPANCY){
         youtubePlayer.seekTo(privateRoomData.timestamp);
     }
+    // When the video is done, the servlet sends back the next videos id
+    // This will not match the currentVideoId, so you must update the current
+    // video to match that of the private rooms video
+    if(privateRoomData.Id !== currentVideoId){
+        loadRoomVideo(privateRoomData.Id, privateRoomData.timestamp);
+    }
     // Change state to match group state
     if(privateRoomData.currentState === PLAYER_STATE_UNSTARTED) {
         console.log('Video is Unstarted');
@@ -144,7 +151,8 @@ function updateCurrentState(currentState, currentTime){
 // The API will call this function when the video player is ready.
 function onPlayerReady(event) {
     document.getElementById('player-div').style.borderColor = '#FF6D00';
-    loadRoomPlaylist();
+    console.log('In the on player ready function');
+    loadRoomVideo(playlistIds[0], 0);
 }
 
 /* Chat Room Feature */

--- a/src/main/webapp/scripts/private-room-script.js
+++ b/src/main/webapp/scripts/private-room-script.js
@@ -41,10 +41,8 @@ function getRoomId(url) {
 }
 
 /**
-* Take in currentRoomId and create a global array of youtube video urls and 
-* a global array of the video ids of the playlist
+* Take in currentRoomId and fetch the current video the private room is on
 * @param {currentRoomId} String Holds the room Id of the the user's room
-* @return {roomVideoUrl} The Url of the video to be displayed for the room
  */
 async function fetchPrivateRoomVideo(currentRoomId) {
     // Check that the current room id exits, then return playlist of given room
@@ -55,11 +53,7 @@ async function fetchPrivateRoomVideo(currentRoomId) {
     currentVideoId = privateRoom.id;
 }
 
-// load the playlist of videos to the container
-function loadRoomPlaylist(){
-    youtubePlayer.loadPlaylist({playlist: playlistIds});
-}
-
+// Load the current video of the private room from the specified start time
 function loadRoomVideo(currentVideoId, startSeconds){
     youtubePlayer.loadVideoById(currentVideoId, startSeconds);
 }
@@ -101,7 +95,7 @@ function onYouTubeIframeAPIReady() {
     });
 }
 
-// Log state changes
+// Log state changes and update the servlet with those changes
 function onStateChange(event) {
     var state = event.data
     playerTimeStamp = Math.round(youtubePlayer.getCurrentTime());
@@ -113,8 +107,8 @@ window.setInterval(function(){
     listenForStateChange();
 }, STATE_LISTENER_TIMER_MS);
 
-// This function fetches the state of the private room video and
-// plays/pauses it accordingly
+// This function fetches the information of the private room and adjusts
+// the time, video id, and state of their personal player accordingly
 async function listenForStateChange(){
     let privateRoomDataPromise = await fetch(SYNC_PATH_WITH_QUERY_PARAM+roomId);
     // fetch the json-version of the urls for all the youtube videos
@@ -148,11 +142,6 @@ async function listenForStateChange(){
     } else {
         console.log('Unknown State');
     }
-}
-
-function getCurrentVideo(){
-    var currentVideoIndex = youtubePlayer.getPlaylistIndex();
-    return playlistIds[currentVideoIndex];
 }
 
 // Send the user's state to the servlet every time their state changes

--- a/src/main/webapp/views/create-room.html
+++ b/src/main/webapp/views/create-room.html
@@ -5,7 +5,7 @@
     <title>Youtube Party</title>
     <link rel="stylesheet" href="../stylesheets/create-room-style.css">
     <script src="../scripts/home_script.js"></script>
-</head onload="authenticate()">
+  </head onload="authenticate('./create-room.html')">
 <body>
 	<nav class="navbar">
     	<div class="container">
@@ -19,14 +19,14 @@
         </div>
     </nav>
     <div id="form-box">
-    	<h1>Create a new Youtube Party</h1>
-    	<form action="/create-room" method="POST">
-        	<label for="fname">PlayList URL:</label><br>
-        	<input aria-label="Url of Playlist" class="input-text" type="text" id="fname" name="fname"><br><br>
-        	<label for="lname">Add invitees(email addresses):</label><br>
-        	<input aria-label="List of Invitees" class="input-text" type="text" id="lname" name="lname"><br><br>
-        	<input id="form-submit-btn" type="submit" value="Submit">
-		</form>
+      <h1>Create a new Youtube Party</h1>
+      <form action="/create-room" method="POST">
+        <label for="PlaylistUrl">PlayList URL:</label><br>
+        <input aria-label="Url of Playlist" class="input-text" type="text" id="fname" name="PlaylistUrl"><br><br>
+        <label for="Invitees">Add invitees(email addresses):</label><br>
+        <input aria-label="List of Invitees" class="input-text" type="text" id="lname" name="Invitees"><br><br>
+        <input id="form-submit-btn" type="submit" value="Submit">
+      </form>
     </div>
 </body>
 </html>

--- a/src/main/webapp/views/private-room.html
+++ b/src/main/webapp/views/private-room.html
@@ -4,7 +4,8 @@
         <meta charset="UTF-8">    
         <title>Private Room</title>    
         <link rel="stylesheet" href="../stylesheets/private-room.css">  
-    </head>  
+    </head>
+    <script src="/scripts/redirect-page-script.js"></script>  
     <script src="/scripts/private-room-script.js"></script>     
     <body onload="loadPlayerDiv(); displayChat()">    
         <div id="player-div"></div>    


### PR DESCRIPTION
Change front end to play current video in playlist for the room instead of loading an entire playlist. 
- loadVideoById instead of loadPlaylistByIds
- Collect a single video at start of room party
- listenForStateChange will also check current video playing against the video id of the private room